### PR TITLE
Bump guzzlehttp/guzzle version 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": ">=6.2"
+    "guzzlehttp/guzzle": ">=6.3.0"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "kasparsj/scopus-search-api",
   "description": "Scopus API for PHP (Unofficial)",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "license": "MIT",
   "version": "1.1",
   "authors": [
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "6.2.1"
+    "guzzlehttp/guzzle": ">=6.2"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
I modified guzzlehttp/guzzle version constraint in the composer.json from `6.2.0` to `>=6.3` to allow a wider version to be installed and to support PHP 7.2 and up.
Related to #2 